### PR TITLE
Ability to resolve over non-local TCP

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -6043,10 +6043,11 @@ static struct dns_packet *dns_cache_fetch(struct dns_cache *cache, int *error) {
 } /* dns_cache_fetch() */
 
 
-static int dns_cache_pollfd(struct dns_cache *cache) {
+dns_pollfd_result dns_cache_pollfd(struct dns_cache *cache) {
 	(void)cache;
 
-	return -1;
+	dns_pollfd_result result = { -1, 0 };
+	return result;
 } /* dns_cache_pollfd() */
 
 
@@ -6797,24 +6798,28 @@ int dns_so_events(struct dns_socket *so) {
 } /* dns_so_events() */
 
 
-int dns_so_pollfd(struct dns_socket *so) {
+dns_pollfd_result dns_so_pollfd(struct dns_socket *so) {
+    dns_pollfd_result result = { -1, dns_so_events2(so, DNS_SYSPOLL) };
 	switch (so->state) {
 	case DNS_SO_UDP_CONN:
 	case DNS_SO_UDP_SEND:
 	case DNS_SO_UDP_RECV:
-		return so->udp;
+		result.fd = so->udp;
+		return result;
 	case DNS_SO_TCP_CONN:
 	case DNS_SO_TCP_SEND:
 	case DNS_SO_TCP_RECV:
-		return so->tcp;
+		result.fd = so->tcp;
+		return result;
 	} /* switch() */
 
-	return -1;
+	return result;
 } /* dns_so_pollfd() */
 
 
 int dns_so_poll(struct dns_socket *so, int timeout) {
-	return dns_poll(dns_so_pollfd(so), dns_so_events2(so, DNS_SYSPOLL), timeout);
+	dns_pollfd_result result = dns_so_pollfd(so);
+	return dns_poll(result.fd, result.want_events, timeout);
 } /* dns_so_poll() */
 
 
@@ -7807,7 +7812,7 @@ int dns_res_events(struct dns_resolver *R) {
 } /* dns_res_events() */
 
 
-int dns_res_pollfd(struct dns_resolver *R) {
+dns_pollfd_result dns_res_pollfd(struct dns_resolver *R) {
 	switch (R->stack[R->sp].state) {
 	case DNS_R_CHECK:
 		return R->cache->pollfd(R->cache);
@@ -7850,7 +7855,8 @@ time_t dns_res_elapsed(struct dns_resolver *R) {
 
 
 int dns_res_poll(struct dns_resolver *R, int timeout) {
-	return dns_poll(dns_res_pollfd(R), dns_res_events2(R, DNS_SYSPOLL), timeout);
+	dns_pollfd_result result = dns_res_pollfd(R);
+	return dns_poll(result.fd, result.want_events, timeout);
 } /* dns_res_poll() */
 
 
@@ -8479,8 +8485,13 @@ int dns_ai_events(struct dns_addrinfo *ai) {
 } /* dns_ai_events() */
 
 
-int dns_ai_pollfd(struct dns_addrinfo *ai) {
-	return (ai->res)? dns_res_pollfd(ai->res) : -1;
+dns_pollfd_result dns_ai_pollfd(struct dns_addrinfo *ai) {
+    if(ai->res) {
+        return dns_res_pollfd(ai->res);
+    } else {
+        dns_pollfd_result result = { -1, 0 };
+        return result;
+    }
 } /* dns_ai_pollfd() */
 
 

--- a/src/dns.h
+++ b/src/dns.h
@@ -962,6 +962,10 @@ typedef unsigned long dns_resconf_i_t;
 
 DNS_PUBLIC size_t dns_resconf_search(void *, size_t, const void *, size_t, struct dns_resolv_conf *, dns_resconf_i_t *);
 
+typedef struct {
+    int fd;
+    int want_events; /* DNS_POLLIN or DNS_POLLOUT, or combination */
+} dns_pollfd_result;
 
 /*
  * H I N T  S E R V E R  I N T E R F A C E
@@ -1024,7 +1028,7 @@ struct dns_cache {
 	int (*check)(struct dns_cache *);
 	struct dns_packet *(*fetch)(struct dns_cache *, int *);
 
-	int (*pollfd)(struct dns_cache *);
+	dns_pollfd_result (*pollfd)(struct dns_cache *);
 	short (*events)(struct dns_cache *);
 	void (*clear)(struct dns_cache *);
 
@@ -1123,7 +1127,7 @@ DNS_PUBLIC void dns_so_clear(struct dns_socket *);
 
 DNS_PUBLIC int dns_so_events(struct dns_socket *);
 
-DNS_PUBLIC int dns_so_pollfd(struct dns_socket *);
+DNS_PUBLIC dns_pollfd_result dns_so_pollfd(struct dns_socket *);
 
 DNS_PUBLIC int dns_so_poll(struct dns_socket *, int);
 
@@ -1165,7 +1169,7 @@ DNS_PUBLIC void dns_res_clear(struct dns_resolver *);
 
 DNS_PUBLIC int dns_res_events(struct dns_resolver *);
 
-DNS_PUBLIC int dns_res_pollfd(struct dns_resolver *);
+DNS_PUBLIC dns_pollfd_result dns_res_pollfd(struct dns_resolver *);
 
 DNS_PUBLIC time_t dns_res_timeout(struct dns_resolver *);
 
@@ -1199,7 +1203,7 @@ DNS_PUBLIC void dns_ai_clear(struct dns_addrinfo *);
 
 DNS_PUBLIC int dns_ai_events(struct dns_addrinfo *);
 
-DNS_PUBLIC int dns_ai_pollfd(struct dns_addrinfo *);
+DNS_PUBLIC dns_pollfd_result dns_ai_pollfd(struct dns_addrinfo *);
 
 DNS_PUBLIC time_t dns_ai_timeout(struct dns_addrinfo *);
 


### PR DESCRIPTION
If using non-local DNS resolver, the large replies can't be received using the existing interface. We need to be able to wait for `POLLOUT` event when we want to await TCP connection establishment. Therefore we expose the want_events through pollfd interfaces.