### PR TITLE
Various fixes

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -28,6 +28,9 @@
 #define _XOPEN_SOURCE	600
 #endif
 
+#undef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+
 #undef _BSD_SOURCE
 #define _BSD_SOURCE
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -203,10 +203,11 @@
 #endif
 
 #ifndef HAVE_STATIC_ASSERT
-#if DNS_GNUC_PREREQ(0,0,0) && !DNS_GNUC_PREREQ(4,6,0)
-#define HAVE_STATIC_ASSERT 0 /* glibc doesn't check GCC version */
+#if (defined static_assert) && \
+	(!DNS_GNUC_PREREQ(0,0,0) || DNS_GNUC_PREREQ(4,6,0)) /* glibc doesn't check GCC version */
+#define HAVE_STATIC_ASSERT 1
 #else
-#define HAVE_STATIC_ASSERT (defined static_assert)
+#define HAVE_STATIC_ASSERT 0
 #endif
 #endif
 
@@ -372,7 +373,11 @@ const char *dns_strerror(int error) {
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #ifndef HAVE___ATOMIC_FETCH_ADD
-#define HAVE___ATOMIC_FETCH_ADD (defined __ATOMIC_RELAXED)
+#ifdef __ATOMIC_RELAXED
+#define HAVE___ATOMIC_FETCH_ADD 1
+#else
+#define HAVE___ATOMIC_FETCH_ADD 0
+#endif
 #endif
 
 #ifndef HAVE___ATOMIC_FETCH_SUB
@@ -779,7 +784,11 @@ DNS_NOTUSED static size_t dns_strnlcpy(char *dst, size_t lim, const char *src, s
 } /* dns_strnlcpy() */
 
 
-#define DNS_HAVE_SOCKADDR_UN (defined AF_UNIX && !defined _WIN32)
+#if (defined AF_UNIX && !defined _WIN32)
+#define DNS_HAVE_SOCKADDR_UN 1
+#else
+#define DNS_HAVE_SOCKADDR_UN 0
+#endif
 
 static size_t dns_af_len(int af) {
 	static const size_t table[AF_MAX]	= {
@@ -6114,11 +6123,19 @@ static void dns_socketclose(int *fd, const struct dns_options *opts) {
 #endif
 
 #ifndef HAVE_SOCK_CLOEXEC
-#define HAVE_SOCK_CLOEXEC (defined SOCK_CLOEXEC)
+#ifdef SOCK_CLOEXEC
+#define HAVE_SOCK_CLOEXEC 1
+#else
+#define HAVE_SOCK_CLOEXEC 0
+#endif
 #endif
 
 #ifndef HAVE_SOCK_NONBLOCK
-#define HAVE_SOCK_NONBLOCK (defined SOCK_NONBLOCK)
+#ifdef SOCK_NONBLOCK
+#define HAVE_SOCK_NONBLOCK 1
+#else
+#define HAVE_SOCK_NONBLOCK 0
+#endif
 #endif
 
 #define DNS_SO_MAXTRY	7

--- a/src/dns.c
+++ b/src/dns.c
@@ -4419,6 +4419,7 @@ struct dns_resolv_conf *dns_resconf_open(int *error) {
 	};
 	struct dns_resolv_conf *resconf;
 	struct sockaddr_in *sin;
+	size_t len;
 
 	if (!(resconf = malloc(sizeof *resconf)))
 		goto syerr;
@@ -4436,13 +4437,11 @@ struct dns_resolv_conf *dns_resconf_open(int *error) {
 	if (0 != gethostname(resconf->search[0], sizeof resconf->search[0]))
 		goto syerr;
 
-	dns_d_anchor(resconf->search[0], sizeof resconf->search[0], resconf->search[0], strlen(resconf->search[0]));
-	dns_d_cleave(resconf->search[0], sizeof resconf->search[0], resconf->search[0], strlen(resconf->search[0]));
-
-	/*
-	 * XXX: If gethostname() returned a string without any label
-	 *      separator, then search[0][0] should be NUL.
-	 */
+	len = strlen(resconf->search[0]);
+	len = dns_d_anchor(resconf->search[0], sizeof resconf->search[0], resconf->search[0], len);
+	len = dns_d_cleave(resconf->search[0], sizeof resconf->search[0], resconf->search[0], len);
+	if (1 == len) /* gethostname() returned a string without any label */
+		resconf->search[0][0] = '\0';
 
 	dns_resconf_acquire(resconf);
 


### PR DESCRIPTION
  - Bring in aliasing fix from cqueues
  - Fix https://github.com/wahern/cqueues/issues/156#issuecomment-340228470
  - Fix #25
  - Fix `-Wexpansion-to-defined` warnings
  - Fix `-Wimplicit-fallthrough` warnings

Now only warnings with GCC 8.1.1 is about `-Warray-bounds` which you explicitly quieten, but only for clang.