### PR TITLE
Fixed a GCC 9.1.0 build error

### DIFF
--- a/src/dns.h
+++ b/src/dns.h
@@ -161,9 +161,14 @@ DNS_PUBLIC int *dns_debug_p(void);
 #define DNS_PRAGMA_QUIET _Pragma("GCC diagnostic ignored \"-Woverride-init\"")
 #define DNS_PRAGMA_POP _Pragma("GCC diagnostic pop")
 
+#if __GNUC__ < 9
 /* GCC parses the _Pragma operator less elegantly than clang. */
 #define dns_quietinit(...) \
 	__extension__ ({ DNS_PRAGMA_PUSH DNS_PRAGMA_QUIET __VA_ARGS__; DNS_PRAGMA_POP })
+#else
+#define dns_quietinit(...) __VA_ARGS__
+#endif
+
 #else
 #define DNS_PRAGMA_PUSH
 #define DNS_PRAGMA_QUIET


### PR DESCRIPTION
On gcc 9.1.0 it builds fine without the dns_quietinit workaround.
That workaround, however, creates its own build issues...